### PR TITLE
Remove nargs='+' when parsing fitness function argument

### DIFF
--- a/src/utilities/algorithm/command_line_parser.py
+++ b/src/utilities/algorithm/command_line_parser.py
@@ -285,7 +285,6 @@ def parse_cmd_args(arguments):
     parser.add_argument('--fitness_function',
                         dest='FITNESS_FUNCTION',
                         type=str,
-                        nargs='+',
                         help='Sets the fitness function to be used. '
                              'Requires string such as "regression". '
                              'Multiple fitness functions can be specified'


### PR DESCRIPTION
If nargs='+' parameter is supplied to args parse it is automatically creating a list even if a single fitness function is supplied.

Due to this we are starting multile objective optimization:

https://github.com/jmmcd/PonyGE2/blob/master/src/utilities/algorithm/initialise_run.py#L152
```
if isinstance(params[op], list):
    # List of fitness functions given.
```
And then creating a multi objective function:
https://github.com/jmmcd/PonyGE2/blob/master/src/utilities/algorithm/initialise_run.py#L168-L172
```
# Import base multi-objective fitness function class.
from fitness.base_ff_classes.moo_ff import moo_ff
        
# Set main fitness function as base multi-objective fitness
# function class.
params[op] = moo_ff(params[op])
```

Possibly the problem is only when supplying the argument from command line.